### PR TITLE
EMA-105950, add support for EMA

### DIFF
--- a/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingScrollView.m
@@ -20,6 +20,8 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidChangeNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.h
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.h
@@ -12,4 +12,12 @@
 @interface TPKeyboardAvoidingTableView : UITableView <UITextFieldDelegate, UITextViewDelegate>
 - (BOOL)focusNextTextField;
 - (void)scrollToActiveTextField;
+/**
+ Table views sometimes interact negatively with keeping the cursor visible while typing.
+ This method allows clients to disable that functionality.
+ 
+ @param keepCursorVisible 'YES' - keeps the cursor visible while typing
+                          'NO'  - doesn't keep cursor visible while typing
+ */
+- (void)keepCursorVisibleWhileTyping:(BOOL)keepCursorVisible;
 @end

--- a/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
+++ b/TPKeyboardAvoiding/TPKeyboardAvoidingTableView.m
@@ -22,6 +22,8 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(TPKeyboardAvoiding_keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidBeginEditingNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidBeginEditingNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidChangeNotification object:nil];
 }
 
 -(id)initWithFrame:(CGRect)frame {
@@ -112,6 +114,18 @@
     [super layoutSubviews];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) object:self];
     [self performSelector:@selector(TPKeyboardAvoiding_assignTextDelegateForViewsBeneathView:) withObject:self afterDelay:0.1];
+}
+
+#pragma mark - Cursor Handling
+
+- (void)keepCursorVisibleWhileTyping:(BOOL)keepCursorVisible {
+    if (keepCursorVisible) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextViewTextDidChangeNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(scrollToActiveTextField) name:UITextFieldTextDidChangeNotification object:nil];
+    } else {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UITextViewTextDidChangeNotification object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UITextFieldTextDidChangeNotification object:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
Addressed 3 issues:
- The keyboard rect was transformed into the scroll view's coordinate space immediately after the keyboard appeared.  This is ok until the scroll view is scrolled and the bounds origin changes.  Changed to transform to the scroll view's coord system on demand when the value is needed.
- The cursor was centered in the visible area.  This causes an issue for table view's with section headers.  The section header's float over the scroll view so the scroll view isn't aware of them and sometimes the cursor can be positioned under the section header.  Changed to position the cursor just above the keyboard to mitigate this.
- The cursor is not adjusted as the user types, so it's possible for the cursor to move below the keyboard after typing multiple lines of text requiring the user to scroll the view up to continue to see the cursor.  Made change to adjust the cursor as you type so this happens automatically.